### PR TITLE
Group system events by system and dynamically add new datasets to chart

### DIFF
--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -219,7 +219,7 @@ class SystemEventsTimeseriesLineChartView {
           pointRadius: 8));
       });
 
-    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets.toList());
+    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets);
 
     var chartOptions = new chartjs.ChartOptions(
       legend: new chartjs.ChartLegendOptions(display: false),
@@ -234,10 +234,9 @@ class SystemEventsTimeseriesLineChartView {
         ],
         yAxes: [
           new chartjs.ChartYAxe()
-            ..ticks = (new chartjs.LinearTickOptions()
-              ..beginAtZero = true)
-              ..display = false
-              ..gridLines = (new chartjs.GridLineOptions(zeroLineWidth: 0))
+            ..ticks = (new chartjs.LinearTickOptions()..beginAtZero = true)
+            ..display = false
+            ..gridLines = (new chartjs.GridLineOptions(zeroLineWidth: 0))
         ]),
       hover: new chartjs.ChartHoverOptions()..animationDuration = 0
     );

--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -210,14 +210,14 @@ class SystemEventsTimeseriesLineChartView {
 
     List<chartjs.ChartDataSets> chartDatasets = [];
     datasetLabels.forEach((datasetLabel) {
-          chartDatasets.add(new chartjs.ChartDataSets(
-              label: datasetLabel,
-              backgroundColor: 'rgba(36, 171, 184, 0.3)',
-              borderColor: '#2B8991',
-              data: [],
-              showLine: false,
-              pointRadius: 8));
-          });
+      chartDatasets.add(new chartjs.ChartDataSets(
+          label: datasetLabel,
+          backgroundColor: 'rgba(36, 171, 184, 0.3)',
+          borderColor: '#2B8991',
+          data: [],
+          showLine: false,
+          pointRadius: 8));
+      });
 
     chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets.toList());
 

--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
 import 'dart:html';
+
+import 'package:crypto/crypto.dart';
 import 'package:chartjs/chartjs.dart' as chartjs;
 
 class SingleIndicatorChartView {
@@ -180,11 +183,11 @@ class DailyTimeseriesLineChartView {
 }
 
 class SystemEventsTimeseriesLineChartView {
-  String project;
   DivElement chartContainer;
   DivElement title;
   CanvasElement canvas;
   chartjs.Chart chart;
+  Map<String, chartjs.ChartDataSets> chartDatasets;
   chartjs.ChartData chartData;
 
   SystemEventsTimeseriesLineChartView() {
@@ -201,25 +204,24 @@ class SystemEventsTimeseriesLineChartView {
     title = new DivElement()
       ..classes.add('chart__title');
     chartContainer.append(title);
+
+    chartDatasets = {};
   }
 
-  void createEmptyChart({String projectName, String titleText = '', List<String> datasetLabels = const []}) {
+  void createEmptyChart({String titleText = '', List<String> datasetLabels = const []}) {
     title.text = titleText;
 
-    project = projectName;
+    for (var datasetLabel in datasetLabels) {
+      chartDatasets.putIfAbsent(datasetLabel, () => new chartjs.ChartDataSets(
+          label: datasetLabel,
+          backgroundColor: '${_stringToHexColor(datasetLabel)}80',
+          borderColor: _stringToHexColor(datasetLabel),
+          data: [],
+          showLine: false,
+          pointRadius: 8));
+    }
 
-    List<chartjs.ChartDataSets> chartDatasets = [];
-    datasetLabels.forEach((datasetLabel) => {
-          chartDatasets.add(new chartjs.ChartDataSets(
-              label: datasetLabel,
-              backgroundColor: 'rgba(36, 171, 184, 0.3)',
-              borderColor: '#2B8991',
-              data: [],
-              showLine: false,
-              pointRadius: 8))
-        });
-
-    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets);
+    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets.values.toList());
 
     var chartOptions = new chartjs.ChartOptions(
       legend: new chartjs.ChartLegendOptions(display: false),
@@ -235,8 +237,7 @@ class SystemEventsTimeseriesLineChartView {
         yAxes: [
           new chartjs.ChartYAxe()
             ..ticks = (new chartjs.LinearTickOptions()
-              ..beginAtZero = true
-              ..max = 2)
+              ..beginAtZero = true)
               ..display = false
               ..gridLines = (new chartjs.GridLineOptions(zeroLineWidth: 0))
         ]),
@@ -247,22 +248,34 @@ class SystemEventsTimeseriesLineChartView {
     chart = chartjs.Chart(canvas.getContext('2d'), chartConfig);
   }
 
-  void updateChart(List<Map<DateTime, Map<String, String>>> updatedCountsAtTimestampList, {String chartLabel = '', String timeScaleUnit = 'day', num upperLimit}) {
-    for (var i = 0; i < updatedCountsAtTimestampList.length; i++) {
+  void updateChart(Map<String, Map<DateTime, num>> updatedCountsAtTimestampList, {String timeScaleUnit = 'day', num upperLimit}) {
+    // Clearing up previous data
+    chartDatasets.clear();
+    chartData.datasets.clear();
+
+    // Show new data
+    updatedCountsAtTimestampList.forEach((datasetLabel, data) {
       List<chartjs.ChartPoint> timeseriesPoints = [];
-      List<DateTime> sortedDateTimes = updatedCountsAtTimestampList[i].keys.toList()
+      List<DateTime> sortedDateTimes = data.keys.toList()
         ..sort((t1, t2) => t1.compareTo(t2));
       for (var datetime in sortedDateTimes) {
-        double value = double.parse(updatedCountsAtTimestampList[i][datetime]['y']);
+        var value = data[datetime];
         timeseriesPoints.add(
             new chartjs.ChartPoint(t: datetime.toIso8601String(), y: value));
-        chartData.datasets[i].label = updatedCountsAtTimestampList[i][datetime]['label'];
-        chartData.datasets[i].backgroundColor = updatedCountsAtTimestampList[i][datetime]['color'];
       }
-      chartData.datasets[i].data
-        ..clear()
-        ..addAll(timeseriesPoints);
-    }
+      chartDatasets.putIfAbsent(datasetLabel, () {
+        var newChartDataset = new chartjs.ChartDataSets(
+          label: datasetLabel,
+          backgroundColor: '${_stringToHexColor(datasetLabel)}4D',
+          borderColor: _stringToHexColor(datasetLabel),
+          data: [],
+          showLine: false,
+          pointRadius: 8,
+          hoverRadius: 8);
+        chartData.datasets.add(newChartDataset);
+        return newChartDataset;
+      }).data.addAll(timeseriesPoints);
+    });
     var timeScaleOptions = new chartjs.TimeScale(unit: timeScaleUnit);
     if (timeScaleUnit == 'hour') {
       timeScaleOptions.stepSize = 2;
@@ -275,4 +288,7 @@ class SystemEventsTimeseriesLineChartView {
     }
     chart.update(new chartjs.ChartUpdateProps(duration: 0));
   }
+
+  // Alpha 100%: FF 87%: DE70%: B3 54%: 8A 50%: 80 38%: 61 12%: 1F
+  String _stringToHexColor(str) => '#${md5.convert(utf8.encode(str)).toString().substring(0, 6)}';
 }

--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -187,7 +187,6 @@ class SystemEventsTimeseriesLineChartView {
   DivElement title;
   CanvasElement canvas;
   chartjs.Chart chart;
-  Map<String, chartjs.ChartDataSets> chartDatasets;
   chartjs.ChartData chartData;
 
   SystemEventsTimeseriesLineChartView() {
@@ -204,24 +203,23 @@ class SystemEventsTimeseriesLineChartView {
     title = new DivElement()
       ..classes.add('chart__title');
     chartContainer.append(title);
-
-    chartDatasets = {};
   }
 
   void createEmptyChart({String titleText = '', List<String> datasetLabels = const []}) {
     title.text = titleText;
 
-    for (var datasetLabel in datasetLabels) {
-      chartDatasets.putIfAbsent(datasetLabel, () => new chartjs.ChartDataSets(
-          label: datasetLabel,
-          backgroundColor: '${_stringToHexColor(datasetLabel)}80',
-          borderColor: _stringToHexColor(datasetLabel),
-          data: [],
-          showLine: false,
-          pointRadius: 8));
-    }
+    List<chartjs.ChartDataSets> chartDatasets = [];
+    datasetLabels.forEach((datasetLabel) {
+          chartDatasets.add(new chartjs.ChartDataSets(
+              label: datasetLabel,
+              backgroundColor: 'rgba(36, 171, 184, 0.3)',
+              borderColor: '#2B8991',
+              data: [],
+              showLine: false,
+              pointRadius: 8));
+          });
 
-    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets.values.toList());
+    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets.toList());
 
     var chartOptions = new chartjs.ChartOptions(
       legend: new chartjs.ChartLegendOptions(display: false),
@@ -250,7 +248,6 @@ class SystemEventsTimeseriesLineChartView {
 
   void updateChart(Map<String, Map<DateTime, num>> updatedCountsAtTimestampList, {String timeScaleUnit = 'day', num upperLimit}) {
     // Clearing up previous data
-    chartDatasets.clear();
     chartData.datasets.clear();
 
     // Show new data
@@ -263,18 +260,16 @@ class SystemEventsTimeseriesLineChartView {
         timeseriesPoints.add(
             new chartjs.ChartPoint(t: datetime.toIso8601String(), y: value));
       }
-      chartDatasets.putIfAbsent(datasetLabel, () {
-        var newChartDataset = new chartjs.ChartDataSets(
-          label: datasetLabel,
-          backgroundColor: '${_stringToHexColor(datasetLabel)}4D',
-          borderColor: _stringToHexColor(datasetLabel),
-          data: [],
-          showLine: false,
-          pointRadius: 8,
-          hoverRadius: 8);
-        chartData.datasets.add(newChartDataset);
-        return newChartDataset;
-      }).data.addAll(timeseriesPoints);
+      var newChartDataset = new chartjs.ChartDataSets(
+        label: datasetLabel,
+        backgroundColor: '${_stringToHexColor(datasetLabel)}4D',
+        borderColor: _stringToHexColor(datasetLabel),
+        data: [],
+        showLine: false,
+        pointRadius: 8,
+        hoverRadius: 8);
+      newChartDataset.data.addAll(timeseriesPoints);
+      chartData.datasets.add(newChartDataset);
     });
     var timeScaleOptions = new chartjs.TimeScale(unit: timeScaleUnit);
     if (timeScaleUnit == 'hour') {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -309,7 +309,7 @@ class ContentView {
   charts.DailyTimeseriesLineChartView diskUsageSystemMetricsTimeseries;
   charts.DailyTimeseriesLineChartView memoryUsageSystemMetricsTimeseries;
   charts.HistogramChartView needsReplyAgeHistogram;
-  List<charts.SystemEventsTimeseriesLineChartView> systemEventsCharts = [];
+  Map<String, charts.SystemEventsTimeseriesLineChartView> systemEventsCharts;
 
   ContentView() {
     projectSelectorView = new ProjectSelectorView();
@@ -392,6 +392,8 @@ class ContentView {
     systemChartsTabContent = new DivElement()
       ..id = "systems";
 
+    systemEventsCharts = {};
+
     cpuPercentSystemMetricsTimeseries = new charts.DailyTimeseriesLineChartView();
     systemChartsTabContent.append(cpuPercentSystemMetricsTimeseries.chartContainer);
     cpuPercentSystemMetricsTimeseries.createEmptyChart(
@@ -412,17 +414,16 @@ class ContentView {
   }
 
   void createSystemEventsCharts(Map<String, List<model.SystemEventsData>> systemEventsProjectsData) {
-    systemEventsProjectsData.forEach((projectName, projectData){
-      if (systemEventsCharts.singleWhere((c) => c.project == projectName, orElse: () => null) == null) {
+    systemEventsProjectsData.forEach((projectName, projectData) {
+      systemEventsCharts.putIfAbsent(projectName, () {
         var systemEventsChart = new charts.SystemEventsTimeseriesLineChartView();
         systemChartsTabContent.insertAdjacentElement('afterbegin', systemEventsChart.chartContainer);
         systemEventsChart.createEmptyChart(
-          projectName: projectName,
           titleText: '$projectName [system events]',
           datasetLabels: List.filled(projectData.length, '', growable: true)
         );
-        systemEventsCharts.add(systemEventsChart);
-      }
+        return systemEventsChart;
+      });
     });
   }
 


### PR DESCRIPTION
This PR aims to fix the issues encountered in #49 

It principally does a few things:
* `updatedCountsAtTimestampList` for system charts is now a map of {systemName: data}. This way we can just iterate over each system name and transform its data into a chart dataset.
* in `updateChart`, we just clear up `chartData` and add new datasets one by one - this was the main fix for the error that was being thrown in the console
* `systemEventsCharts` is now a map of {project: chart} - this way we can just call `putIfAbsent` to add new project charts (as well as if needed, directly index into it for a project's chart rather than having to search for it every time)
* Small adjustments to colour - kept the `_stringToHexColor` just for the hex RGB value, and set a fixed 30% alpha value only for the background of the data point.
