### PR TITLE
Add charts for monitoring drivers

### DIFF
--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -293,3 +293,113 @@ class SystemEventsTimeseriesLineChartView {
 
   String _stringToHexColor(str) => '#${md5.convert(utf8.encode(str)).toString().substring(0, 6)}';
 }
+
+class DriverTimeseriesBarChartView {
+  DivElement chartContainer;
+  DivElement title;
+  CanvasElement canvas;
+  chartjs.Chart chart;
+  chartjs.ChartData chartData;
+
+  DriverTimeseriesBarChartView() {
+    chartContainer = new DivElement()
+      ..classes.add('chart');
+
+    canvas = new CanvasElement(height: 300, width: 800);
+
+    // Wrap the canvas into a <div> element as needed by Chart.js
+    chartContainer.append(new DivElement()
+      ..classes.add('chart--3080')
+      ..append(canvas));
+
+    title = new DivElement()
+      ..classes.add('chart__title');
+    chartContainer.append(title);
+  }
+
+  void createEmptyChart({String titleText = '', List<String> datasetLabels = const []}) {
+    title.text = titleText;
+
+    List<chartjs.ChartDataSets> chartDatasets = [];
+    datasetLabels.forEach((datasetLabel) {
+      chartDatasets.add(new chartjs.ChartDataSets(
+          label: datasetLabel,
+          backgroundColor: 'rgba(36, 171, 184, 0.3)',
+          borderColor: '#2B8991',
+          data: [],
+          showLine: false,
+          pointRadius: 8));
+      });
+
+    chartData = new chartjs.ChartData(labels: [], datasets: chartDatasets);
+
+    var chartOptions = new chartjs.ChartOptions(
+      legend: new chartjs.ChartLegendOptions(display: false),
+      scales: new chartjs.LinearScale(
+        xAxes: [
+          new chartjs.ChartXAxe()
+            ..type = 'time'
+            ..distribution = 'linear'
+            ..bounds = 'ticks'
+            ..time = (new chartjs.TimeScale(unit: 'day'))
+            ..gridLines = (new chartjs.GridLineOptions(zeroLineWidth: 0))
+        ],
+        yAxes: [
+          new chartjs.ChartYAxe()
+            ..ticks = (new chartjs.LinearTickOptions()..beginAtZero = true)
+            ..gridLines = (new chartjs.GridLineOptions(zeroLineWidth: 0))
+        ]),
+      hover: new chartjs.ChartHoverOptions()..animationDuration = 0,
+      tooltips: new chartjs.ChartTooltipOptions()..mode = 'x-axis',
+    );
+
+    var chartConfig = new chartjs.ChartConfiguration(type: 'bar', data: chartData, options: chartOptions);
+    chart = chartjs.Chart(canvas.getContext('2d'), chartConfig);
+  }
+
+  void updateChart(Map<String, Map<DateTime, num>> updatedCountsAtTimestampList, {String timeScaleUnit = 'day', num yLowerLimit = 0 , num yUpperLimit, DateTime xLowerLimit, DateTime xUpperLimit}) {
+    // Clearing up previous data
+    chartData.datasets.clear();
+
+    // Show new data
+    updatedCountsAtTimestampList.forEach((datasetLabel, data) {
+      List<chartjs.ChartPoint> timeseriesPoints = [];
+      List<DateTime> sortedDateTimes = data.keys.toList()
+        ..sort((t1, t2) => t1.compareTo(t2));
+      for (var datetime in sortedDateTimes) {
+        var value = data[datetime];
+        timeseriesPoints.add(
+            new chartjs.ChartPoint(t: datetime.toIso8601String(), y: value));
+      }
+      var newChartDataset = new chartjs.ChartDataSets(
+        label: datasetLabel,
+        backgroundColor: '${_stringToHexColor(datasetLabel)}',
+        borderColor: '${_stringToHexColor(datasetLabel)}',
+        data: [],
+        showLine: false,
+        pointRadius: 2,
+        hoverRadius: 4,
+        spanGaps: false);
+      newChartDataset.data.addAll(timeseriesPoints);
+      chartData.datasets.add(newChartDataset);
+    });
+    var timeScaleOptions = new chartjs.TimeScale(unit: timeScaleUnit);
+    if (timeScaleUnit == 'hour') {
+      timeScaleOptions.stepSize = 2;
+    }
+    chart.options.scales.xAxes[0].time = timeScaleOptions;
+    chart.options.scales.xAxes[0].type = 'time';
+    chart.options.scales.xAxes[0].ticks.min = xLowerLimit?.toIso8601String();
+    chart.options.scales.xAxes[0].ticks.max = xUpperLimit?.toIso8601String();
+    chart.options.scales.xAxes[0].stacked = true;
+
+    chart.options.scales.yAxes[0].stacked = true;
+    chart.options.scales.yAxes[0].ticks.min = yLowerLimit;
+    if (yUpperLimit != null) {
+      chart.options.scales.yAxes[0].ticks.max = yUpperLimit;
+    }
+    chart.update(new chartjs.ChartUpdateProps(duration: 0));
+  }
+
+  String _stringToHexColor(str) => '#${md5.convert(utf8.encode(str)).toString().substring(0, 6)}';
+}

--- a/webapp/lib/charts.dart
+++ b/webapp/lib/charts.dart
@@ -379,7 +379,9 @@ class DriverTimeseriesBarChartView {
         showLine: false,
         pointRadius: 2,
         hoverRadius: 4,
-        spanGaps: false);
+        spanGaps: false,
+        barPercentage: 1.0,
+        barThickness: 750 / xUpperLimit.difference(xLowerLimit).inMinutes);
       newChartDataset.data.addAll(timeseriesPoints);
       chartData.datasets.add(newChartDataset);
     });

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -514,6 +514,8 @@ void updateDriverCharts(Map<String, List<model.DriverData>> filteredDriversDataM
     metricNames = metricNames.toSet().toList()..sort();
     datetimes = datetimes.toSet().toList()..sort();
 
+    // Initialise the data to zero for all metrics and timestamps,
+    // otherwise the bar chart doesn't work well.
     Map<String, Map<DateTime, num>> chartData = {};
     for (var metric in metricNames) {
       chartData[metric] = {};

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -142,7 +142,7 @@ void initUI() {
   listenForDriverMetrics(selectedProject, DRIVERS);
   listenForSystemEvents(PROJECTS);
   listenForSystemMetrics();
-  // listenForDirectoryMetrics(); // no longer in use
+  // listenForDirectoryMetrics(); // not yet in use
 }
 
 void listenForNeedsReplyMetrics(String project) {

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -18,7 +18,7 @@ final DIR_SIZE_METRICS_ROOT_COLLECTION_KEY = 'dir_size_metrics';
 final PROJECTS = ['Lark_KK-Project-2020-COVID19', 'Lark_KK-Project-2020-COVID19-KE-URBAN',
   'Lark_KK-Project-2020-COVID19-SOM-CC', 'Lark_KK-Project-2020-COVID19-SOM-IMAQAL', 'Lark_KK-Project-2020-COVID19-SOM-UNICEF'];
 
-final DRIVERS = ['coda_adapter', 'firebase_adapter', 'pubsub_handler'];
+final DRIVERS = ['coda_adapter', 'pubsub_handler', 'firebase_adapter'];
 
 enum UIAction {
   userSignedIn,

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -146,11 +146,6 @@ void initUI() {
 }
 
 void listenForNeedsReplyMetrics(String project) {
-  // // don't start listening again if the new project is the same as the selected one
-  // if (project == selectedProject) {
-  //   log.warning('New project is the same as the selected one, skip resetting the needs reply collection listener');
-  //   return;
-  // }
   // clear up the old data while the new data loads
   needsReplyDataList.clear();
   command(UIAction.needsReplyDataUpdated, null);
@@ -175,12 +170,6 @@ void listenForNeedsReplyMetrics(String project) {
 }
 
 void listenForDriverMetrics(String project, List<String> drivers) {
-  print('listen for driver metrics');
-  // // don't start listening again if the new project is the same as the selected one
-  // if (project == selectedProject) {
-  //   log.warning('New project is the same as the selected one, skip resetting the needs reply collection listener');
-  //   return;
-  // }
   // clear up the old data while the new data loads
   driversDataMap.clear();
   command(UIAction.driversDataUpdated, null);

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -45,6 +45,40 @@ class NeedsReplyData {
   }
 }
 
+class DriverData {
+  String docId;
+  DateTime datetime;
+  Map<String, int> metrics;
+
+  static DriverData fromSnapshot(DocSnapshot doc) =>
+      fromData(doc.data)..docId = doc.id;
+
+  static DriverData fromData(Map data) {
+    if (data == null) return null;
+    DateTime datetime = DateTime_fromData(data['datetime']);
+    Map<String, int> metrics = {};
+    data.forEach((key, value) {
+      if (key == 'datetime') return;
+      metrics[String_fromData(key)] = int_fromData(value);
+    });
+    return DriverData()
+      ..datetime = datetime
+      ..metrics = metrics;
+  }
+
+  Map<String, dynamic> toData() {
+    return {
+      if (datetime != null) 'datetime': datetime.toIso8601String(),
+      ...metrics,
+    };
+  }
+
+  @override
+  String toString() {
+    return '$docId: ${toData()}';
+  }
+}
+
 class SystemEventsData {
   String docId;
   String event;
@@ -87,7 +121,7 @@ class SystemMetricsData {
   double cpuPercent;
   Map<String, double> diskUsage;
   Map<String, double> memoryUsage;
-  
+
   static SystemMetricsData fromSnapshot(DocSnapshot doc) =>
     fromData(doc.data)..docId = doc.id;
 
@@ -110,7 +144,7 @@ class SystemMetricsData {
       if (memoryUsage != null) 'memory_usage': memoryUsage
     };
   }
-  
+
   static double sizeInGB(double bytes) =>
       double.parse((bytes / (1024.0 * 1024.0 * 1024.0)).toStringAsFixed(1));
 
@@ -126,7 +160,7 @@ class DirectorySizeMetricsData {
   String dirname;
   DateTime timestamp;
   double sizeInMB;
-  
+
   static DirectorySizeMetricsData fromSnapshot(DocSnapshot doc) =>
       fromData(doc.data)..docId = doc.id;
 

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase/firebase.dart' as firebase;
 import 'package:firebase/firestore.dart' as firestore;
 import 'package:nook_watcher/model.dart';
@@ -57,9 +59,9 @@ bool isUserSignedIn() {
 
 typedef CollectionListener(List<DocSnapshot> changes);
 
-void listenForMetrics(String collectionRoot, CollectionListener listener) {
+StreamSubscription listenForMetrics(String collectionRoot, CollectionListener listener) {
   log.verbose('Loading from metrics');
-  _firestoreInstance
+  return _firestoreInstance
         .collection(collectionRoot)
         .onSnapshot.listen((snapshots) {
           List<DocSnapshot> changes = [];

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -289,12 +289,14 @@ class ContentView {
   DivElement tabElement;
   ButtonElement _systemTabLink;
   ButtonElement _conversationTabLink;
+  ButtonElement _driverTabLink;
 
   ProjectSelectorView projectSelectorView;
 
   DivElement contentElement;
-  DivElement systemChartsTabContent;
   DivElement conversationChartsTabContent;
+  DivElement driverChartsTabContent;
+  DivElement systemChartsTabContent;
   DivElement chartDataLastUpdateTime;
 
   charts.SingleIndicatorChartView needsReplyLatestValue;
@@ -309,6 +311,7 @@ class ContentView {
   charts.DailyTimeseriesLineChartView diskUsageSystemMetricsTimeseries;
   charts.DailyTimeseriesLineChartView memoryUsageSystemMetricsTimeseries;
   charts.HistogramChartView needsReplyAgeHistogram;
+  Map<String, charts.DriverTimeseriesBarChartView> driverCharts;
   Map<String, charts.SystemEventsTimeseriesLineChartView> systemEventsCharts;
 
   ContentView() {
@@ -322,6 +325,11 @@ class ContentView {
       ..text = "Conversations"
       ..onClick.listen((_) => controller.command(controller.UIAction.tabSwitched, new controller.ChartTypeData(controller.ChartType.conversation)));
     tabElement.append(_conversationTabLink);
+
+    _driverTabLink = new ButtonElement()
+      ..text = "Drivers"
+      ..onClick.listen((_) => controller.command(controller.UIAction.tabSwitched, new controller.ChartTypeData(controller.ChartType.driver)));
+    tabElement.append(_driverTabLink);
 
     _systemTabLink = new ButtonElement()
       ..text = "Systems"
@@ -389,6 +397,10 @@ class ContentView {
       titleText: 'needs reply messages by date',
       datasetLabel: 'needs reply messages by date');
 
+    driverChartsTabContent = new DivElement()
+      ..id = "drivers";
+    driverCharts = {};
+
     systemChartsTabContent = new DivElement()
       ..id = "systems";
 
@@ -427,6 +439,25 @@ class ContentView {
     });
   }
 
+  void createDriverCharts(Map<String, List<model.DriverData>> driversData) {
+    driversData.forEach((driverName, driverData) {
+      driverCharts.putIfAbsent(driverName, () {
+        var driverChart = new charts.DriverTimeseriesBarChartView();
+        driverChartsTabContent.insertAdjacentElement('afterbegin', driverChart.chartContainer);
+        driverChart.createEmptyChart(
+          titleText: '$driverName',
+          datasetLabels: List.filled(0, '', growable: true)
+        );
+        return driverChart;
+      });
+    });
+  }
+
+  clearDriverCharts() {
+    driverCharts.clear();
+    driverChartsTabContent.children.clear();
+  }
+
   void set stale (bool staleState) {
     if (staleState) {
       _conversationCharts.forEach((chart) => chart.classes.add('stale'));
@@ -446,12 +477,19 @@ class ContentView {
         contentElement.append(systemChartsTabContent);
         _systemTabLink.classes.add('active');
         projectSelectorView.projectSelector.classes.add('hidden');
-      break;
+        break;
+
       case controller.ChartType.conversation:
         contentElement.append(conversationChartsTabContent);
         _conversationTabLink.classes.add('active');
         projectSelectorView.projectSelector.classes.remove('hidden');
-      break;
+        break;
+
+      case controller.ChartType.driver:
+        contentElement.append(driverChartsTabContent);
+        _driverTabLink.classes.add('active');
+        projectSelectorView.projectSelector.classes.remove('hidden');
+        break;
     }
   }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -265,21 +265,30 @@ class ChartFiltersView {
   String _periodFilterValue (controller.ChartPeriodFilters filter) {
     String filteredValue;
     switch (filter) {
-      case controller.ChartPeriodFilters.alltime:
-        filteredValue = 'All Time';
+      case controller.ChartPeriodFilters.hours1:
+        filteredValue = '1 hour';
+        break;
+      case controller.ChartPeriodFilters.hours4:
+        filteredValue = '4 hours';
+        break;
+      case controller.ChartPeriodFilters.hours10:
+        filteredValue = '10 hours';
         break;
       case controller.ChartPeriodFilters.days1:
         filteredValue = '1 Day';
-      break;
+        break;
       case controller.ChartPeriodFilters.days8:
         filteredValue = '8 days';
-      break;
+        break;
       case controller.ChartPeriodFilters.days15:
         filteredValue = '15 days';
-      break;
+        break;
       case controller.ChartPeriodFilters.month1:
         filteredValue = '1 month';
-      break;
+        break;
+      case controller.ChartPeriodFilters.alltime:
+        filteredValue = 'All Time';
+        break;
     }
     return filteredValue;
   }
@@ -506,11 +515,11 @@ class ContentView {
     return controller.ChartType.values.singleWhere((v) => v.toString() == 'ChartType.$type', orElse: () => null);
   }
 
-  String getProjectFilter() {
+  String getProjectUrlFilter() {
     return UrlView.getPageUrlFilters()['project'];
   }
 
-  controller.ChartPeriodFilters getChartPeriodFilter() {
+  controller.ChartPeriodFilters getChartPeriodUrlFilter() {
     String periodFilter = UrlView.getPageUrlFilters()['period-filter'];
     return controller.ChartPeriodFilters.values.singleWhere((v) => v.toString() == 'ChartPeriodFilters.$periodFilter', orElse: () => null);
   }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -452,7 +452,7 @@ class ContentView {
     driversData.forEach((driverName, driverData) {
       driverCharts.putIfAbsent(driverName, () {
         var driverChart = new charts.DriverTimeseriesBarChartView();
-        driverChartsTabContent.insertAdjacentElement('afterbegin', driverChart.chartContainer);
+        driverChartsTabContent.insertAdjacentElement('beforeend', driverChart.chartContainer);
         driverChart.createEmptyChart(
           titleText: '$driverName',
           datasetLabels: List.filled(0, '', growable: true)

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -479,8 +479,9 @@ class ContentView {
 
   void toogleTabView(controller.ChartType chartType) {
     contentElement.children.clear();
-    _systemTabLink.classes.remove('active');
+    _driverTabLink.classes.remove('active');
     _conversationTabLink.classes.remove('active');
+    _systemTabLink.classes.remove('active');
     switch (chartType) {
       case controller.ChartType.system:
         contentElement.append(systemChartsTabContent);


### PR DESCRIPTION
This creates a new "Drivers" tab for showing charts about the drivers behind each project. It also:
- adds new filter periods of 1/4/10 hours for use with these charts (depending on how it works in practice, we may want the other charts to also work with these filters)
- exposes the `StreamSubscription` for the firebase collections, so we can cancel the existing one and start a new one when switching between projects