### PR TITLE
Generalise escalate monitoring to more general tags monitoring

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -200,7 +200,7 @@ void listenForConversationMetrics(String project) {
       var updatedData = updatedMetrics.map((doc) => model.ConversationMetricsData.fromSnapshot(doc)).toList();
       conversationMetricsDataList.removeWhere((d) => updatedIds.contains(d.docId));
       conversationMetricsDataList.addAll(updatedData);
-      var updatedMonitoredTags = updatedData.fold<Set<String>>(new Set(), (tags, data) => tags..addAll(data.tagCountData.keys)).toList();
+      var updatedMonitoredTags = updatedData.fold<Set<String>>(new Set(), (tags, data) => tags..addAll(data.tagsCount.keys)).toList();
       var newMonitoredTags = updatedMonitoredTags.toSet().difference(monitoredConversationTags);
       if (newMonitoredTags.isNotEmpty) {
         for (var tag in newMonitoredTags) {
@@ -577,9 +577,9 @@ void updateConversationCharts(List<model.ConversationMetricsData> filteredConver
   view.contentView.conversationsCountTimeseries.updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
 
   for (var tag in monitoredConversationTags) {
-    data = new Map.fromIterable(filteredConversationMetricsDataList.where((element) => element.tagCountData.containsKey(tag)),
+    data = new Map.fromIterable(filteredConversationMetricsDataList.where((element) => element.tagsCount.containsKey(tag)),
       key: (item) => (item as model.ConversationMetricsData).datetime.toLocal(),
-      value: (item) => (item as model.ConversationMetricsData).tagCountData[tag]);
+      value: (item) => (item as model.ConversationMetricsData).tagsCount[tag]);
     view.contentView.tagCountTimeseriesCharts[tag].updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
   }
 
@@ -598,7 +598,7 @@ void updateConversationCharts(List<model.ConversationMetricsData> filteredConver
 
   view.contentView.conversationsCountValue.updateChart('${latestData.conversationsCount}');
   for (var tag in monitoredConversationTags) {
-    view.contentView.tagCountCharts[tag].updateChart('${latestData.tagCountData[tag]}');
+    view.contentView.tagCountCharts[tag].updateChart('${latestData.tagsCount[tag]}');
   }
 
   filteredConversationMetricsDataList.sort((a, b) => a.datetime.compareTo(b.datetime));

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -115,6 +115,7 @@ List<String> PROJECTS;
 Map<String, List<String>> DRIVERS;
 
 List<model.ConversationMetricsData> conversationMetricsDataList;
+Set<String> monitoredConversationTags;
 Map<String, List<model.DriverData>> driversDataMap;
 Map<String, List<model.SystemEventsData>> systemEventsDataMap;
 List<model.SystemMetricsData> systemMetricsDataList;
@@ -146,6 +147,7 @@ void initUI() async{
   DRIVERS = await platform.projectsDrivers;
 
   conversationMetricsDataList = [];
+  monitoredConversationTags = new Set();
   driversDataMap = {};
   systemEventsDataMap = {};
   systemMetricsDataList = [];
@@ -178,8 +180,10 @@ void initUI() async{
 void listenForConversationMetrics(String project) {
   // clear up the old data while the new data loads
   conversationMetricsDataList.clear();
+  monitoredConversationTags.clear();
   command(UIAction.conversationMetricsDataUpdated, null);
   view.contentView.toggleChartLoadingState(ChartType.conversation, true);
+  view.contentView.clearTagCountCharts();
 
   // start listening for the new project collection
   conversationMetricsSubscription?.cancel();
@@ -196,6 +200,15 @@ void listenForConversationMetrics(String project) {
       var updatedData = updatedMetrics.map((doc) => model.ConversationMetricsData.fromSnapshot(doc)).toList();
       conversationMetricsDataList.removeWhere((d) => updatedIds.contains(d.docId));
       conversationMetricsDataList.addAll(updatedData);
+      var updatedMonitoredTags = updatedData.fold<Set<String>>(new Set(), (tags, data) => tags..addAll(data.tagCountData.keys)).toList();
+      var newMonitoredTags = updatedMonitoredTags.toSet().difference(monitoredConversationTags);
+      if (newMonitoredTags.isNotEmpty) {
+        for (var tag in newMonitoredTags) {
+          view.contentView.addTagCountIndicator(tag);
+          view.contentView.addTagCountTimeseries(tag);
+          monitoredConversationTags.add(tag);
+        }
+      }
       command(UIAction.conversationMetricsDataUpdated, null);
       checkConversationMetricsStale(updatedData);
       view.contentView.toggleChartLoadingState(ChartType.conversation, false);
@@ -563,21 +576,19 @@ void updateConversationCharts(List<model.ConversationMetricsData> filteredConver
     value: (item) => (item as model.ConversationMetricsData).conversationsCount);
   view.contentView.conversationsCountTimeseries.updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
 
-  data = new Map.fromIterable(filteredConversationMetricsDataList,
-    key: (item) => (item as model.ConversationMetricsData).datetime.toLocal(),
-    value: (item) => (item as model.ConversationMetricsData).escalateConversations);
-  view.contentView.escalateConversationsTimeseries.updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
-
-  data = new Map.fromIterable(filteredConversationMetricsDataList,
-    key: (item) => (item as model.ConversationMetricsData).datetime.toLocal(),
-    value: (item) => (item as model.ConversationMetricsData).escalateConversationsOurTurn);
-  view.contentView.escalateConversationsOurTurnTimeseries.updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
+  for (var tag in monitoredConversationTags) {
+    data = new Map.fromIterable(filteredConversationMetricsDataList.where((element) => element.tagCountData.containsKey(tag)),
+      key: (item) => (item as model.ConversationMetricsData).datetime.toLocal(),
+      value: (item) => (item as model.ConversationMetricsData).tagCountData[tag]);
+    view.contentView.tagCountTimeseriesCharts[tag].updateChart([data], timeScaleUnit: timeScaleUnit, xLowerLimit: xLowerLimitDateTime, xUpperLimit: xUpperLimitDateTime);
+  }
 
   if (filteredConversationMetricsDataList.isEmpty) {
     view.contentView.chartDataLastUpdateTime.text = 'No data to show for selected project and time range';
     view.contentView.conversationsCountValue.updateChart('-');
-    view.contentView.escalateConversationsLatestValue.updateChart('-');
-    view.contentView.escalateConversationsOurTurnValue.updateChart('-');
+    for (var tag in monitoredConversationTags) {
+      view.contentView.tagCountCharts[tag].updateChart('-');
+    }
     // TODO: show a message on the timeseries charts saying that there's no data to show
     return;
   }
@@ -586,8 +597,9 @@ void updateConversationCharts(List<model.ConversationMetricsData> filteredConver
   var latestData = filteredConversationMetricsDataList.firstWhere((d) => d.datetime.toLocal() == latestDateTime, orElse: () => null);
 
   view.contentView.conversationsCountValue.updateChart('${latestData.conversationsCount}');
-  view.contentView.escalateConversationsLatestValue.updateChart('${latestData.escalateConversations}');
-  view.contentView.escalateConversationsOurTurnValue.updateChart('${latestData.escalateConversationsOurTurn}');
+  for (var tag in monitoredConversationTags) {
+    view.contentView.tagCountCharts[tag].updateChart('${latestData.tagCountData[tag]}');
+  }
 
   filteredConversationMetricsDataList.sort((a, b) => a.datetime.compareTo(b.datetime));
   DateTime lastUpdateTime = filteredConversationMetricsDataList.last.datetime;

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -6,7 +6,7 @@ class ConversationMetricsData {
   String docId;
   DateTime datetime;
   int conversationsCount;
-  Map<String, int> tagCountData;
+  Map<String, int> tagsCount;
 
   static ConversationMetricsData fromSnapshot(DocSnapshot doc) =>
       fromData(doc.data)..docId = doc.id;
@@ -17,14 +17,14 @@ class ConversationMetricsData {
     return ConversationMetricsData()
       ..datetime = DateTime_fromData(data['datetime'])
       ..conversationsCount = int_fromData(data['conversations_count'])
-      ..tagCountData = Map_fromData(data['tag_count_data'], int_fromData) ?? {};
+      ..tagsCount = Map_fromData(data['tags_count'], int_fromData) ?? {};
   }
 
   Map<String, dynamic> toData() {
     return {
       if (datetime != null) 'datetime': datetime.toIso8601String(),
       if (conversationsCount != null) 'conversations_count': conversationsCount,
-      if (tagCountData != null) 'tag_count_data': tagCountData,
+      if (tagsCount != null) 'tags_count': tagsCount,
     };
   }
 

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -6,8 +6,7 @@ class ConversationMetricsData {
   String docId;
   DateTime datetime;
   int conversationsCount;
-  int escalateConversations;
-  int escalateConversationsOurTurn;
+  Map<String, int> tagCountData;
 
   static ConversationMetricsData fromSnapshot(DocSnapshot doc) =>
       fromData(doc.data)..docId = doc.id;
@@ -18,16 +17,14 @@ class ConversationMetricsData {
     return ConversationMetricsData()
       ..datetime = DateTime_fromData(data['datetime'])
       ..conversationsCount = int_fromData(data['conversations_count'])
-      ..escalateConversations = int_fromData(data['escalate_conversations'])
-      ..escalateConversationsOurTurn = int_fromData(data['escalate_conversations_our_turn']);
+      ..tagCountData = Map_fromData(data['tag_count_data'], int_fromData) ?? {};
   }
 
   Map<String, dynamic> toData() {
     return {
       if (datetime != null) 'datetime': datetime.toIso8601String(),
       if (conversationsCount != null) 'conversations_count': conversationsCount,
-      if (escalateConversations != null) 'escalate_conversations': escalateConversations,
-      if (escalateConversationsOurTurn != null) 'escalate_conversations_our_turn': escalateConversationsOurTurn,
+      if (tagCountData != null) 'tag_count_data': tagCountData,
     };
   }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -306,19 +306,23 @@ class ContentView {
 
   DivElement contentElement;
   DivElement conversationChartsTabContent;
+  DivElement singleIndicators;
   DivElement driverChartsTabContent;
   DivElement systemChartsTabContent;
   DivElement chartDataLastUpdateTime;
 
+  // Conversations monitoring page
   charts.SingleIndicatorChartView conversationsCountValue;
-  charts.SingleIndicatorChartView escalateConversationsLatestValue;
-  charts.SingleIndicatorChartView escalateConversationsOurTurnValue;
+  Map<String, charts.SingleIndicatorChartView> tagCountCharts;
   charts.DailyTimeseriesLineChartView conversationsCountTimeseries;
-  charts.DailyTimeseriesLineChartView escalateConversationsTimeseries;
-  charts.DailyTimeseriesLineChartView escalateConversationsOurTurnTimeseries;
+  Map<String, charts.DailyTimeseriesLineChartView> tagCountTimeseriesCharts;
+
+  // Systems monitoring page
   charts.SystemMetricsTimeseriesBarChartView cpuPercentSystemMetricsTimeseries;
   charts.SystemMetricsTimeseriesBarChartView diskUsageSystemMetricsTimeseries;
   charts.SystemMetricsTimeseriesBarChartView memoryUsageSystemMetricsTimeseries;
+
+  // Drivers monitoring page
   Map<String, charts.DriverTimeseriesBarChartView> driverCharts;
   Map<String, charts.SystemEventsTimeseriesLineChartView> systemEventsCharts;
 
@@ -351,7 +355,7 @@ class ContentView {
     conversationChartsTabContent = new DivElement()
       ..id = "conversations";
 
-    var singleIndicators = new DivElement()
+    singleIndicators = new DivElement()
       ..classes.add('single-indicator-container');
     conversationChartsTabContent.append(singleIndicators);
 
@@ -359,13 +363,7 @@ class ContentView {
       ..createEmptyChart(titleText: 'all conversations');
     singleIndicators.append(conversationsCountValue.chartContainer);
 
-    escalateConversationsLatestValue = new charts.SingleIndicatorChartView()
-      ..createEmptyChart(titleText: 'escalate conversations');
-    singleIndicators.append(escalateConversationsLatestValue.chartContainer);
-
-    escalateConversationsOurTurnValue = new charts.SingleIndicatorChartView()
-      ..createEmptyChart(titleText: 'escalate coversations our turn');
-    singleIndicators.append(escalateConversationsOurTurnValue.chartContainer);
+    tagCountCharts = {};
 
     chartDataLastUpdateTime = new DivElement()
       ..id = 'charts-last-update';
@@ -377,17 +375,7 @@ class ContentView {
       titleText: 'all conversations',
       datasetLabels: ['all conversations']);
 
-    escalateConversationsTimeseries = new charts.DailyTimeseriesLineChartView();
-    conversationChartsTabContent.append(escalateConversationsTimeseries.chartContainer);
-    escalateConversationsTimeseries.createEmptyChart(
-      titleText: 'escalate conversations',
-      datasetLabels: ['escalate conversations']);
-
-    escalateConversationsOurTurnTimeseries = new charts.DailyTimeseriesLineChartView();
-    conversationChartsTabContent.append(escalateConversationsOurTurnTimeseries.chartContainer);
-    escalateConversationsOurTurnTimeseries.createEmptyChart(
-      titleText: 'escalate conversations our turn',
-      datasetLabels: ['escalate conversations our turn']);
+    tagCountTimeseriesCharts = {};
 
     driverChartsTabContent = new DivElement()
       ..id = "drivers";
@@ -432,6 +420,31 @@ class ContentView {
         return systemEventsChart;
       });
     });
+  }
+
+  void addTagCountIndicator(String tag) {
+    var indicator = new charts.SingleIndicatorChartView()
+      ..createEmptyChart(titleText: tag);
+    singleIndicators.append(indicator.chartContainer);
+    tagCountCharts[tag] = indicator;
+  }
+
+  void addTagCountTimeseries(String tag) {
+    var timeseries = new charts.DailyTimeseriesLineChartView();
+    conversationChartsTabContent.append(timeseries.chartContainer);
+    timeseries.createEmptyChart(titleText: tag, datasetLabels: [tag]);
+    tagCountTimeseriesCharts[tag] = timeseries;
+  }
+
+  void clearTagCountCharts() {
+    for (var chart in tagCountCharts.values) {
+      chart.chartContainer.remove();
+    }
+    tagCountCharts.clear();
+    for (var chart in tagCountTimeseriesCharts.values) {
+      chart.chartContainer.remove();
+    }
+    tagCountTimeseriesCharts.clear();
   }
 
   void createDriverCharts(Map<String, List<model.DriverData>> driversData) {
@@ -536,11 +549,9 @@ class ContentView {
     switch (chartType){
       case controller.ChartType.conversation:
         conversationsCountValue.spinner.classes.toggle('hidden', !show);
-        escalateConversationsLatestValue.spinner.classes.toggle('hidden', !show);
-        escalateConversationsOurTurnValue.spinner.classes.toggle('hidden', !show);
+        tagCountCharts.forEach((tag, chart) => chart.spinner.classes.toggle('hidden', !show));
         conversationsCountTimeseries.spinner.classes.toggle('hidden', !show);
-        escalateConversationsTimeseries.spinner.classes.toggle('hidden', !show);
-        escalateConversationsOurTurnTimeseries.spinner.classes.toggle('hidden', !show);
+        tagCountTimeseriesCharts.forEach((tag, chart) => chart.spinner.classes.toggle('hidden', !show));
         break;
       case controller.ChartType.driver:
         driverCharts.forEach((driver, chart) => chart.spinner.classes.toggle('hidden', !show));


### PR DESCRIPTION
We're soon wanting to monitor more conversation tags than escalate, so this generalises the dashboard to show an indicator chart and a timeseries for any `<tag>: <count>` pair.